### PR TITLE
This commit fixes #3 and #4

### DIFF
--- a/src/benchmarktool/src/main/java/sbst/benchmark/junit/StoppingJUnitCore.java
+++ b/src/benchmarktool/src/main/java/sbst/benchmark/junit/StoppingJUnitCore.java
@@ -1,0 +1,258 @@
+package sbst.benchmark.junit;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunListener;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runner.notification.StoppedByUserException;
+
+import sbst.benchmark.Main;
+import sbst.benchmark.pitest.TestInfo;
+
+// For very large number of test classes this might not work as you can not easily specify tons of inputs on the commandline !
+public class StoppingJUnitCore {
+
+    final AtomicBoolean globalTimeout = new AtomicBoolean(false);
+    
+    class StoppingListener extends RunListener {
+        private RunNotifier runNotifier = null;
+        private Set<TestInfo> flakyTests = null;
+        private RunListener listener = null;
+        
+        public StoppingListener(RunNotifier runNotifier, Set<TestInfo> flakyTests, Result theResult) {
+            this.runNotifier = runNotifier;
+            this.flakyTests = flakyTests;
+            // This let us collect the results of the run and keep it there also after we "kill" JUnitCore
+            this.listener = theResult.createListener();
+            
+        }
+
+        @Override
+        public void testFailure(Failure failure) throws Exception {
+            super.testFailure(failure);
+            //
+            String header = failure.getTestHeader();
+            Main.debug("Failed test " + header);
+            if (header.contains("(")) {
+                String testMethod = header.substring(0, header.indexOf('('));
+                String tc = header.substring(header.indexOf('(') + 1, header.length());
+                TestInfo info = new TestInfo(tc, testMethod);
+                // If the failed test is flaky
+                if (flakyTests.contains(info)) {
+                    // Keep going
+                    Main.debug("\t flaky test, ignore !");
+                    listener.testAssumptionFailure(failure);
+                    return;
+                } else
+                // If the failed test is a timeout
+                if (failure.getTrace().contains("java.lang.Exception: test timed out after")) {
+                    // Keep going
+                    Main.debug("\t timeout test, ignore !");
+                    listener.testAssumptionFailure(failure);
+                } else if (failure.getException() instanceof InterruptedException ){
+                 // Keep going
+                    Main.debug("\t test execution reached (probably GLOABL timeout), will stop test execution but do not report killing test !");
+                    globalTimeout.set(true);
+                    runNotifier.pleaseStop();
+                } else {
+                    Main.debug("\t actual test, will stop test execution !");
+                    listener.testFailure(failure);
+                    runNotifier.pleaseStop();
+                }
+            } else {
+                // This might be a test suite ...
+            }
+        }
+
+        @Override
+        public void testStarted(Description description) throws Exception {
+            super.testStarted(description);
+            listener.testRunStarted(description);
+//            Main.debug(">>SBST: " + description.getClassName() + "." + description.getMethodName() + " started");
+            
+        }
+
+        @Override
+        public void testFinished(Description description) throws Exception {
+            super.testFinished(description);
+            listener.testFinished(description);
+//            Main.debug(">>SBST: " + description.getClassName() + "." + description.getMethodName() + " finished");
+        }
+        
+        @Override
+        public void testAssumptionFailure(Failure failure) {
+            super.testAssumptionFailure(failure);
+            listener.testAssumptionFailure(failure);
+        }
+        
+        @Override
+        public void testIgnored(Description description) throws Exception {
+            super.testIgnored(description);
+            listener.testIgnored(description);
+        }
+    }
+
+    /**
+     * Changes the annotation value for the given key of the given annotation to
+     * newValue and returns the previous value.
+     */
+    @SuppressWarnings("unchecked")
+    public static Object changeAnnotationValue(Annotation annotation, String key, Object newValue) {
+        Object handler = Proxy.getInvocationHandler(annotation);
+        Field f;
+        try {
+            f = handler.getClass().getDeclaredField("memberValues");
+        } catch (NoSuchFieldException | SecurityException e) {
+            throw new IllegalStateException(e);
+        }
+        f.setAccessible(true);
+        Map<String, Object> memberValues;
+        try {
+            memberValues = (Map<String, Object>) f.get(handler);
+        } catch (IllegalArgumentException | IllegalAccessException e) {
+            throw new IllegalStateException(e);
+        }
+        Object oldValue = memberValues.get(key);
+        if (oldValue == null || oldValue.getClass() != newValue.getClass()) {
+            throw new IllegalArgumentException();
+        }
+        memberValues.put(key, newValue);
+        return oldValue;
+    }
+
+    public Result run(Class testClass, //
+            long timeout, //
+            final Set<TestInfo> flakyTests) {
+        JUnitCore junit = new JUnitCore();
+        final Result theResult = new Result();
+        try {
+            // Make it possible to stop the execution by invoking the
+            // pleaseStop()
+            // method.
+            for (Field field : junit.getClass().getDeclaredFields()) {
+                if (field.getName().equals("notifier") || field.getName().equals("fNotifier")) {
+                    field.setAccessible(true);
+                    RunNotifier runNotifier;
+                    runNotifier = (RunNotifier) field.get(junit);
+                    junit.addListener(new StoppingListener(runNotifier, flakyTests, theResult));
+                }
+            }
+
+            // NOTE: This assumes that tests are annotated using @Test !
+            // TODO This is fragile, one should instead enforce it in the source
+            // code before compiling the class !
+            for (Method testMethod : testClass.getDeclaredMethods()) {
+                final Test methodAnnotation = testMethod.getAnnotation(Test.class);
+                // Consider ONLY the test methods annotated using @Test
+                if (methodAnnotation != null && methodAnnotation.timeout() == 0) {
+                    changeAnnotationValue(methodAnnotation, "timeout", timeout);
+                }
+            }
+            // If no tests fail, this will return the Result object
+            return junit.run(testClass);
+        } catch (StoppedByUserException e) {
+            // If this is triggered because of global timeout we should not report any result !
+            if( globalTimeout.get() ){
+                Main.info("Global timeout reached while executing tests.");
+                return null;
+            } else {
+            // If a test failed we forced JUnitCore to stop. So we need to
+            // "recreate" a suitable Result object
+            return theResult;
+            }
+        } catch (Throwable t) {
+            Main.info("Failed Test execution with JUNIT CORE: ");
+            t.printStackTrace(Main.infoStr);
+            throw new RuntimeException("Cannot execute test with StoppingJUnitCore");
+        }
+    }
+
+    // // Tweak JUnitCore to be more user friendly and stop at the first error
+    // // Should we enforce some timeout/error ?!
+    // public static void main(String[] args) throws NoSuchFieldException,
+    // SecurityException, IllegalArgumentException,
+    // IllegalAccessException, InvocationTargetException {
+    // JUnitCore junit = new JUnitCore();
+    //
+    // // Make it possible to stop the execution by invoking the pleaseStop()
+    // // method.
+    // Field field = junit.getClass().getDeclaredField("notifier");
+    // field.setAccessible(true);
+    // final RunNotifier runNotifier = (RunNotifier) field.get(junit);
+    //
+    // junit.addListener(new RunListener() {
+    // @Override
+    // public void testFailure(Failure failure) throws Exception {
+    // super.testFailure(failure);
+    // System.out.println("SBST:" + " " + failure.getTestHeader());
+    // // If the error cause is really needed we can parse it as well:
+    // System.err.println(">>SBST:" + " " + failure.getTrace());
+    // runNotifier.pleaseStop();
+    //
+    // }
+    //
+    // @Override
+    // public void testStarted(Description description) throws Exception {
+    // super.testStarted(description);
+    // System.err.println(
+    // ">>SBST: " + description.getClassName() + "." +
+    // description.getMethodName() + " started");
+    // }
+    //
+    // @Override
+    // public void testFinished(Description description) throws Exception {
+    // super.testFinished(description);
+    // System.err.println(
+    // ">>SBST: " + description.getClassName() + "." +
+    // description.getMethodName() + " finished");
+    // }
+    // });
+    //
+    // // The following code is similar to JUnitCore.runMain except for
+    // // registering the default TextListener
+    // List<Class<?>> classes = new ArrayList<Class<?>>();
+    // List<Failure> missingClasses = new ArrayList<Failure>();
+    // for (String each : args) {
+    // try {
+    // classes.add(Class.forName(each));
+    // } catch (ClassNotFoundException e) {
+    // System.err.println("Could not find test class: " + each);
+    // System.exit(2);
+    // }
+    // }
+    //
+    // // Enforce all the tests to specify a timeout of 5000 if no timeout is
+    // // already there
+    // // NOTE: This assumes that tests are annotated using @Test !
+    // // TODO This is fragile, one should instead enforce it in the source
+    // // code before compiling the class !
+    // for (Class testClass : classes) {
+    // for (Method testMethod : testClass.getDeclaredMethods()) {
+    // final Test methodAnnotation = testMethod.getAnnotation(Test.class);
+    // // Consider ONLY the test methods annotated using @Test
+    // if (methodAnnotation != null && methodAnnotation.timeout() == 0) {
+    // changeAnnotationValue(methodAnnotation, "timeout", new Long(5000));
+    // }
+    // }
+    // }
+    //
+    // // Execute the tests
+    // Result result = junit.run(classes.toArray(new Class[0]));
+    // for (Failure each : missingClasses) {
+    // result.getFailures().add(each);
+    // }
+    // // TODO Serialize result to file using XStream
+    // System.exit(result.wasSuccessful() ? 0 : 1);
+    // }
+}

--- a/src/benchmarktool/src/main/java/sbst/benchmark/pitest/MutationAnalysis.java
+++ b/src/benchmarktool/src/main/java/sbst/benchmark/pitest/MutationAnalysis.java
@@ -35,12 +35,17 @@ public class MutationAnalysis {
 
 	/** Map to keep track of covered mutations **/
 	private MutationSet coveredMutants;
+	
+	/** Map to keep track of covered mutations **/
+    private List<MutationIdentifier> ignoredMutants;
 
 	/** Map to keep track of the mutation being killed **/
 	private Map<MutationIdentifier, Boolean> killData;
 
 	/** Map to keep track of tests killing/covering mutations **/
 	private Map<MutationIdentifier, List<TestInfo>> coveringTests;
+	
+	
 
 	/**
 	 * Simple constructor to initiate the coverage information
@@ -60,6 +65,8 @@ public class MutationAnalysis {
 			else
 				uncoveredMutants.addMutant(id, this.generatedMutants.getMutantion(id), this.generatedMutants.getMutantionDetails(id));
 		}
+		
+		this.ignoredMutants = new ArrayList<>();
 
 		this.killData = new HashMap<MutationIdentifier, Boolean>();
 		this.coveringTests = new HashMap<MutationIdentifier, List<TestInfo>>();
@@ -81,15 +88,19 @@ public class MutationAnalysis {
 			this.coveringTests.put(mutant.getId(), list);
 		}
 	}
+	
+    public void addIgnoreMutant(MutationDetails mutant) {
+        this.ignoredMutants.add(mutant.getId());
+    }
 
 	/**
 	 * Add mutation as uncovered/non-killed
 	 * @param mutant mutation being covered
 	 */
 	public void addAliveMutant(MutationDetails mutant){		
-                Boolean killed = this.killData.get(mutant.getId());
-                if (killed == null || !killed) // if it was killed => ignore
-                        this.killData.put(mutant.getId(), false);		
+	    Boolean killed = this.killData.get(mutant.getId());
+            if (killed == null || !killed) // if it was killed => ignore
+                this.killData.put(mutant.getId(), false);		
 	}
 
 	public int getNumberOfMutations(){
@@ -106,6 +117,10 @@ public class MutationAnalysis {
 		}
 		return count;
 	}
+	
+	public int numberOfIgnoredMutation(){
+        return this.ignoredMutants.size();
+    }
 
 	public int numberOfUncoveredMutation(){
 		return this.uncoveredMutants.getNumberOfMutations();
@@ -129,6 +144,7 @@ public class MutationAnalysis {
 		String info = "N. of generated mutants "+this.getNumberOfMutations()+"\n";
 		info = info + "N. of covered mutants "+this.getNumberOfCoveredMutants()+"\n";
 		info = info + "N. of killed mutants "+this.numberOfKilledMutation()+"\n";
+		info = info + "N. of ignored mutants "+this.numberOfIgnoredMutation()+"\n";
 		String mutation_list = "";
 		String test_info = "";
 		int count = 0;
@@ -178,5 +194,6 @@ public class MutationAnalysis {
 	public int getNumberOfCoveredMutants() {
 		return coveredMutants.getNumberOfMutations();
 	}
+
 
 }

--- a/src/benchmarktool/src/main/java/sbst/benchmark/pitest/MutationResults.java
+++ b/src/benchmarktool/src/main/java/sbst/benchmark/pitest/MutationResults.java
@@ -21,17 +21,30 @@ import org.pitest.mutationtest.engine.MutationIdentifier;
 
 public class MutationResults {
 
+    public enum State { SURVIVED, KILLED, IGNORED, NEVER_RUN }
+    
 	/** junit results */
 	private List<Result> results = new ArrayList<Result>();
 
 	/** ID of the mutation */
 	private MutationIdentifier mutation_id;
 
+	private State state;
+	
 	public MutationResults(List<Result> pResults, MutationIdentifier id){
 		this.mutation_id = id;
 		this.results = pResults;
+		this.state = State.NEVER_RUN;
 	}
 
+	public State getState() {
+        return state;
+    }
+	
+	public void setState(State state) {
+        this.state = state;
+    }
+	
 	public List<Result> getJUnitResults() {
 		return results;
 	}
@@ -43,5 +56,7 @@ public class MutationResults {
 	public void addJUnitResult(Result r){
 		this.results.add(r);
 	}
+	
+	
 
 }

--- a/src/benchmarktool/src/main/java/sbst/benchmark/pitest/MutationsEvaluator.java
+++ b/src/benchmarktool/src/main/java/sbst/benchmark/pitest/MutationsEvaluator.java
@@ -18,17 +18,18 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+
+import javax.management.RuntimeErrorException;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.runner.Result;
@@ -41,239 +42,295 @@ import sbst.benchmark.coverage.JacocoResult;
 
 public class MutationsEvaluator {
 
-	private static final int MAX_THREAD = 1;
+    private static final int MAX_THREAD = 1;
 
-	private static final long GLOBAL_TIMEOUT = 300000; // global timeout for mutation analysis
+    private static final long GLOBAL_TIMEOUT = 300000; // global timeout for
+                                                       // mutation analysis
 
-	/** Folder where to save the mutated SUT **/
-	private String tempFolder;
+    /** Folder where to save the mutated SUT **/
+    private String tempFolder;
 
-	private String classPath;
+    private String classPath;
 
-	private String classToMutate;
+    private String classToMutate;
 
-	private List<String> targetTest;
+    private List<String> targetTest;
 
-	private MutationAnalysis mutationResults;
+    private MutationAnalysis mutationResults;
 
-	private Set<TestInfo> flakyTests;
+    private Set<TestInfo> flakyTests;
 
-	private boolean timeoutReached = false;
+    private boolean timeoutReached = false;
 
-	/**
-	 * Build the infrastructure to run the generated tests against the mutations
-	 * @param pClassPath classpath with all required libraries to run the tests
-	 * @param pClassToMutate name of the class to mutate
-	 * @param pTargetTest test to run against the mutations
-	 */
-	public MutationsEvaluator(String pClassPath, String pClassToMutate, List<String> pTargetTest, Set<TestInfo> pFlakyTests){
-		this.classPath = pClassPath;
-		this.classToMutate = pClassToMutate;
-		this.targetTest = pTargetTest;
-		this.flakyTests = pFlakyTests;
-	}
+    /**
+     * Build the infrastructure to run the generated tests against the mutations
+     * 
+     * @param pClassPath
+     *            classpath with all required libraries to run the tests
+     * @param pClassToMutate
+     *            name of the class to mutate
+     * @param pTargetTest
+     *            test to run against the mutations
+     */
+    public MutationsEvaluator(String pClassPath, String pClassToMutate, List<String> pTargetTest,
+            Set<TestInfo> pFlakyTests) {
+        this.classPath = pClassPath;
+        this.classToMutate = pClassToMutate;
+        this.targetTest = pTargetTest;
+        this.flakyTests = pFlakyTests;
+    }
 
-	public void computeCoveredMutants(MutationSet set, JacocoResult jacoco){
-		mutationResults = new MutationAnalysis(set, jacoco);
-	}
+    public void computeCoveredMutants(MutationSet set, JacocoResult jacoco) {
+        mutationResults = new MutationAnalysis(set, jacoco);
+    }
 
-	/**
-	 * This method run all covered mutations. It makes a copy of the SUT in the
-	 * @param tempFolder folder where the SUT will be copied for the mutation analysis
-	 * @param path2SUT path of the "original" SUT
-	 * @throws ClassNotFoundException
-	 * @throws IOException
-	 * @throws InterruptedException
-	 * @throws ExecutionException
-	 * @throws TimeoutException
-	 */
-	public void runMutations(String tempFolder, String path2SUT) throws ClassNotFoundException, IOException, InterruptedException, ExecutionException {
-		// create a temporary copy of the SUT for mutation analysis
-		this.tempFolder = tempFolder;
-		if (tempFolder.equals(path2SUT))
-			throw new IllegalArgumentException("Source and target directories should be different: \n "
-					+ "source directory = "+path2SUT
-					+ "target directory = "+ tempFolder);
+    /**
+     * This method run all covered mutations. It makes a copy of the SUT in the
+     * 
+     * @param tempFolder
+     *            folder where the SUT will be copied for the mutation analysis
+     * @param path2SUT
+     *            path of the "original" SUT
+     * @throws ClassNotFoundException
+     * @throws IOException
+     * @throws InterruptedException
+     * @throws ExecutionException
+     * @throws TimeoutException
+     */
+    public void runMutations(String tempFolder, String path2SUT)
+            throws ClassNotFoundException, IOException, InterruptedException, ExecutionException {
+        // create a temporary copy of the SUT for mutation analysis
+        this.tempFolder = tempFolder;
+        if (tempFolder.equals(path2SUT))
+            throw new IllegalArgumentException("Source and target directories should be different: \n "
+                    + "source directory = " + path2SUT + "target directory = " + tempFolder);
 
-		// create a copy of the SUT
-		String newSUT = this.tempFolder+"/SUT";
+        // create a copy of the SUT
+        String newSUT = this.tempFolder + "/SUT";
 
-		createSUTCopy(path2SUT, newSUT);
-		// remove the original CUT
-		String CUT =  newSUT + "/" + classToMutate.replace('.','/')+".class";
-		File fcut = new File(CUT);
-		if (fcut.exists())
-			FileUtils.deleteQuietly(fcut);
+        createSUTCopy(path2SUT, newSUT);
+        // remove the original CUT
+        String CUT = newSUT + "/" + classToMutate.replace('.', '/') + ".class";
+        File fcut = new File(CUT);
+        if (fcut.exists())
+            FileUtils.deleteQuietly(fcut);
 
-		// Prepare the ExecutorService
-		ExecutorService service = Executors.newScheduledThreadPool(MAX_THREAD);
+        // Prepare the ExecutorService
+        ExecutorService service = Executors.newScheduledThreadPool(MAX_THREAD);
 
-		// start to measure the time
-		long start_time = System.currentTimeMillis();
+        // start to measure the time
+        long start_time = System.currentTimeMillis();
 
-		// iterate over all mutations
-		MutationSet coveredMutants = mutationResults.getCoveredMutants();
-		Set<MutationIdentifier> mutations = coveredMutants.getMutationIDs();
+        // iterate over all mutations
+        MutationSet coveredMutants = mutationResults.getCoveredMutants();
+        Set<MutationIdentifier> mutations = coveredMutants.getMutationIDs();
 
-		LinkedList<TestExec4MutationTask> task_list = new LinkedList<TestExec4MutationTask>();
+        LinkedList<TestExec4MutationTask> task_list = new LinkedList<TestExec4MutationTask>();
 
-		int mutation_counter = -1;
-		for (MutationIdentifier id : mutations){
-			//System.out.println(coveredMutants.getMutantionDetails(id).toString());
-			//System.out.println(">> "+ coveredMutants.getMutantionDetails(id).getClassName());
-			//System.out.println(">> "+ coveredMutants.getMutantionDetails(id).getMethod());
+        int mutation_counter = -1;
+        for (MutationIdentifier id : mutations) {
+            // System.out.println(coveredMutants.getMutantionDetails(id).toString());
+            // System.out.println(">> "+
+            // coveredMutants.getMutantionDetails(id).getClassName());
+            // System.out.println(">> "+
+            // coveredMutants.getMutantionDetails(id).getMethod());
 
-			mutation_counter++;
+            mutation_counter++;
 
-			// get the mutated bytecode of the CUT
-			byte[] mu = coveredMutants.getMutantion(id).getBytes();
+            // get the mutated bytecode of the CUT
+            byte[] mu = coveredMutants.getMutantion(id).getBytes();
 
-			// save the mutated bytecode of the CUT
-			String newCUT =  this.tempFolder + "/CUT"+mutation_counter;
-			writeMutationOnDisk(mu, newCUT);
+            // save the mutated bytecode of the CUT
+            String newCUT = this.tempFolder + "/CUT" + mutation_counter;
+            writeMutationOnDisk(mu, newCUT);
 
-			// change the classpath to consider the new copy of the SUT
-			String newCP = this.classPath.replace(path2SUT, newSUT);
-			// add the mutated CUT to the classpath
-			newCP = newCP+":"+newCUT;
+            // change the classpath to consider the new copy of the SUT
+            String newCP = this.classPath.replace(path2SUT, newSUT);
+            // add the mutated CUT to the classpath
+            newCP = newCP + ":" + newCUT;
 
-			// run the test against the mutated CUT
-			List<String> testClasses = new ArrayList<String>();
-			testClasses.addAll(this.targetTest);
+            // run the test against the mutated CUT
+            List<String> testClasses = new ArrayList<String>();
+            testClasses.addAll(this.targetTest);
 
-			//Main.debug("## Run test with CP = "+ newCP);
-			TestExec4MutationTask executor = new TestExec4MutationTask(newCP, testClasses, this.flakyTests, id);
-			task_list.addLast(executor);
-		}
-		List<Future<MutationResults>> all = service.invokeAll(task_list,GLOBAL_TIMEOUT, TimeUnit.MILLISECONDS);
+            // This will run each test class against the mutant !
+            TestExec4MutationTask executor = new TestExec4MutationTask(newCP, testClasses, this.flakyTests, id);
+            task_list.addLast(executor);
+        }
 
-		for (Future<MutationResults> future : all){
-			try {
-				// if canceled let's notify printing a file in the result directory
-				if (future.isCancelled()){
-					this.timeoutReached = true;
-					continue;
-				}
+        // TODO What to do if one Mutant screw up all the
+        List<Future<MutationResults>> all = service.invokeAll(task_list, GLOBAL_TIMEOUT, TimeUnit.MILLISECONDS);
+        service.shutdown();
 
-				MutationResults mutation_result = future.get(TestSuite.TEST_TIMEOUT,TimeUnit.MILLISECONDS);
+        for (Future<MutationResults> future : all) {
+            try {
+                // if canceled let's notify printing a file in the result
+                // directory
+                if (future.isCancelled()) {
+                    Main.debug("\n Ignoring mutant for timeout : " + future.get());
+                    this.timeoutReached = true;
+                    continue;
+                }
 
-				List<Result> executionResults = mutation_result.getJUnitResults();
-				MutationIdentifier id = mutation_result.getMutation_id();
+                MutationResults mutationResult = future.get(TestSuite.TEST_TIMEOUT, TimeUnit.MILLISECONDS);
+                MutationIdentifier id = mutationResult.getMutation_id();
 
-				if (executionResults == null){
-					mutationResults.addAliveMutant(coveredMutants.getMutantionDetails(id));
-					continue;
-				}
+                switch (mutationResult.getState()) {
+                case KILLED:
+                    TestInfo info = null;
 
-				for (Result result : executionResults){
-					// if no failure, it means that the test did not kill the mutation
-					if (result.getFailures().size() == 0)
-						mutationResults.addAliveMutant(coveredMutants.getMutantionDetails(id));
-					else {
-						for (Failure fail : result.getFailures()){
-							if (!fail.getTrace().contains("java.io.FileNotFoundException")){
-								String header = fail.getTestHeader();
-								//Main.debug("Failure: "+fail.getTestHeader()+"\n"+fail.getTrace());
-								if (header.contains("(")){
-									String testMethod = header.substring(0, header.indexOf('('));
-									String testClass = header.substring(header.indexOf('(')+1, header.length());
-									TestInfo info = new TestInfo(testClass, testMethod);
-									mutationResults.addKilledMutant(coveredMutants.getMutantionDetails(id), info);
-								} else {
-									//Main.debug(" \n #### \n "+fail.getTestHeader()+"\n"+fail.getMessage()+"\n"+fail.getTrace()+" \n #### \n ");
-								}
-							}
-						}
-					}
-				}
-			} catch (Throwable e) {
-				// TODO Auto-generated catch block
-				if (e instanceof TimeoutException) {
-					Main.debug("Evaluation of the mutant stopped: it took more than "+TestSuite.TEST_TIMEOUT+" milliseconds");
-					//MutationIdentifier id = mutationIndexes.get(future);
-					//TestInfo info = new TestInfo("Timeout", "Timeout");
-					//mutationResults.addKilledMutant(coveredMutants.getMutantionDetails(id), info);
-				}
-				e.printStackTrace(Main.debugStr);
-				continue;
-			}
-		}
-		service.shutdown();
+                    // Lookup the killing test information
+                    List<Result> executionResults = mutationResult.getJUnitResults();
+                    for (Result result : executionResults) {
+                        for (Failure fail : result.getFailures()) {
 
-		// remove temporary directory
-		File dire2remove = new File(this.tempFolder);
-		if (dire2remove.exists() && dire2remove.isDirectory())
-			FileUtils.deleteDirectory(dire2remove);
-	}
+                            String header = fail.getTestHeader();
+                            // Skip results that have to be ignored anyway
+                            if (fail.getTrace().contains("java.lang.Exception: test timed out after")
+                                    || fail.getTrace().contains("java.io.FileNotFoundException")) {
+                                Main.debug("\n Discard test execution");
+                                continue;
+                            }
+                            // Check
+                            if (header.contains("(")) {
+                                String testMethod = header.substring(0, header.indexOf('('));
+                                String testClass = header.substring(header.indexOf('(') + 1, header.length());
+                                info = new TestInfo(testClass, testMethod);
 
-	/**
-	 * Create a copy of the SUT for mutation analysis
-	 * @param path2SUT path to the SUT
-	 * @param tempFolder temporary file used for mutation analysis
-	 */
-	public static void createSUTCopy(String path2SUT, String tempFolder){
-		File source = new File(path2SUT);
-		File target = new File(tempFolder);
+                                if (!this.flakyTests.contains(info)) {
+                                    Main.debug("Mutant " + coveredMutants.getMutantionDetails(id) + " killed by " + info
+                                            + "with " + fail.getTrace());
+                                    break;
+                                } else {
+                                    Main.debug("Mutant " + coveredMutants.getMutantionDetails(id) + " killed by " + info
+                                            + "which is flaky. Ignore the result");
+                                }
+                            }
+                        }
+                    }
 
-		try {
-			if (path2SUT.contains(":")){
-				String[] libraries = path2SUT.split(":");
-				for (String lib : libraries){
-					lib = lib.replace(":", "");
-					if (lib.length()>0){
-						File fileLib= new File(lib);
-						if (fileLib.isDirectory())
-							FileUtils.copyDirectory(fileLib, target);
-						else
-							FileUtils.copyFileToDirectory(fileLib, target);
-					}
-				}
-			} else {
-				if (!source.exists())
-					throw new FileNotFoundException();
-				FileUtils.copyDirectory(source, target);
-			}
+                    if (info != null) {
+                        mutationResults.addKilledMutant(coveredMutants.getMutantionDetails(id), info);
+                    } else {
+                        // Is this an error ?
+                        throw new RuntimeException("Cannot find the killing test!");
+                    }
 
+                    break;
 
-		} catch (IOException e) {
-			Main.debug("Could not make a copy of the SUT "+path2SUT);
-			e.printStackTrace(Main.debugStr);
-		}
-	}
+                case SURVIVED:
+                    mutationResults.addAliveMutant(coveredMutants.getMutantionDetails(id));
+                    break;
 
-	/**
-	 * Method to write the mutated CUT on disk (in the folder specified by the attribute tempFolder)
-	 * @param mu bytecode of the mutated CUT (generated by PIT)
-	 * @param location temporary directory where to save the mutated CUT
-	 */
-	public void writeMutationOnDisk(byte[] mu, String location){
+                case IGNORED:
+                    mutationResults.addIgnoreMutant(coveredMutants.getMutantionDetails(id));
+                    break;
 
-		String newCUT = location + "/" + classToMutate.replace('.','/')+".class";
+                default: // NEVER_RUN
+                    mutationResults.addAliveMutant(coveredMutants.getMutantionDetails(id));
+                    break;
+                }
 
-		File changed_code = new File(newCUT);
-		changed_code.getParentFile().mkdirs(); // create required folders
+            } catch (Throwable e) {
+                // TODO Auto-generated catch block
+                if (e instanceof TimeoutException) {
+                    Main.debug("Evaluation of the mutant stopped: it took more than " + TestSuite.TEST_TIMEOUT
+                            + " milliseconds. Discard mutant.");
+                } else if (e instanceof CancellationException) {
+                    Main.debug("Evaluation of the mutant stopped: it took more than " + TestSuite.TEST_TIMEOUT
+                            + " milliseconds. Discard mutant.");
+                } else {
+                    Main.debug("Error in evaluating mutant:");
+                    e.printStackTrace(Main.debugStr);
+                }
+                continue;
+            }
+        }
 
-		FileOutputStream output;
-		try {
-			output = new FileOutputStream(changed_code);
-			output.write(mu);
-			output.flush();
-			output.close();
+        // remove temporary directory
+        File dire2remove = new File(this.tempFolder);
+        if (dire2remove.exists() && dire2remove.isDirectory())
+            FileUtils.deleteDirectory(dire2remove);
+    }
 
-		} catch (FileNotFoundException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		} catch (IOException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
-	}
+    /**
+     * Create a copy of the SUT for mutation analysis
+     * 
+     * @param path2SUT
+     *            path to the SUT
+     * @param tempFolder
+     *            temporary file used for mutation analysis
+     */
+    public static void createSUTCopy(String path2SUT, String tempFolder) {
+        File source = new File(path2SUT);
+        File target = new File(tempFolder);
 
-	public MutationAnalysis getMutationCoverage(){
-		return this.mutationResults;
-	}
+        try {
+            if (path2SUT.contains(":")) {
+                String[] libraries = path2SUT.split(":");
+                for (String lib : libraries) {
+                    lib = lib.replace(":", "");
+                    if (lib.length() > 0) {
+                        File fileLib = new File(lib);
+                        if (fileLib.isDirectory())
+                            FileUtils.copyDirectory(fileLib, target);
+                        else
+                            FileUtils.copyFileToDirectory(fileLib, target);
+                    }
+                }
+            } else {
+                if (!source.exists())
+                    throw new FileNotFoundException();
+                FileUtils.copyDirectory(source, target);
+            }
 
-	public boolean isTimeoutReached(){
-		return timeoutReached;
-	}
+        } catch (IOException e) {
+            Main.debug("Could not make a copy of the SUT " + path2SUT);
+            e.printStackTrace(Main.debugStr);
+        }
+    }
+
+    /**
+     * Method to write the mutated CUT on disk (in the folder specified by the
+     * attribute tempFolder)
+     * 
+     * @param mu
+     *            bytecode of the mutated CUT (generated by PIT)
+     * @param location
+     *            temporary directory where to save the mutated CUT
+     */
+    public void writeMutationOnDisk(byte[] mu, String location) {
+
+        String newCUT = location + "/" + classToMutate.replace('.', '/') + ".class";
+
+        File changed_code = new File(newCUT);
+        changed_code.getParentFile().mkdirs(); // create required folders
+
+        FileOutputStream output;
+        try {
+            output = new FileOutputStream(changed_code);
+            output.write(mu);
+            output.flush();
+            output.close();
+
+        } catch (FileNotFoundException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        } catch (IOException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+    }
+
+    public MutationAnalysis getMutationCoverage() {
+        return this.mutationResults;
+    }
+
+    public boolean isTimeoutReached() {
+        return timeoutReached;
+    }
+
+    public void setTimeoutReached() {
+        this.timeoutReached = true;
+    }
 }

--- a/src/benchmarktool/src/main/java/sbst/benchmark/pitest/TestExec4MutationTask.java
+++ b/src/benchmarktool/src/main/java/sbst/benchmark/pitest/TestExec4MutationTask.java
@@ -22,106 +22,139 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
 
-import org.junit.runner.JUnitCore;
 import org.junit.runner.Result;
 import org.junit.runner.notification.Failure;
 import org.pitest.mutationtest.engine.MutationIdentifier;
 
 import sbst.benchmark.Main;
 import sbst.benchmark.coverage.TestUtil;
+import sbst.benchmark.junit.StoppingJUnitCore;
+import sbst.benchmark.pitest.MutationResults.State;
 
-public class TestExec4MutationTask  implements Callable<MutationResults>{
+public class TestExec4MutationTask implements Callable<MutationResults> {
 
-	private URL[] urls;
-	private List<String> testClasses;
-	private MutationResults results;
-	private Set<TestInfo> flakyTests;
+    private URL[] urls;
+    private List<String> testClasses;
+    private MutationResults results;
+    private Set<TestInfo> flakyTests;
 
-	public TestExec4MutationTask(String cp, List<String> pTestClasses, Set<TestInfo> pFlakyTests, MutationIdentifier id){
-		try {
-			// Load the jar
-			urls = TestUtil.createURLs(cp);
-			testClasses = pTestClasses;
-			this.flakyTests = pFlakyTests;
-			results = new MutationResults(new ArrayList<Result>(), id);
-		} catch (MalformedURLException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
-	}
+    public TestExec4MutationTask(String cp, List<String> pTestClasses, Set<TestInfo> pFlakyTests,
+            MutationIdentifier id) {
+        try {
+            // Load the jar
+            urls = TestUtil.createURLs(cp);
+            testClasses = pTestClasses;
+            this.flakyTests = pFlakyTests;
+            results = new MutationResults(new ArrayList<Result>(), id);
+        } catch (MalformedURLException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+    }
 
-	@Override
-	public MutationResults call() throws ClassNotFoundException, IOException {
+    @Override
+    public MutationResults call() throws ClassNotFoundException, IOException {
 
-			URLClassLoader cl = URLClassLoader.newInstance(urls, this.getClass().getClassLoader());
+        try (URLClassLoader cl = URLClassLoader.newInstance(urls, this.getClass().getClassLoader())) {
 
-			Main.debug("Running the tests: "+testClasses);
-			for (String test : testClasses){
+            Main.debug("Evaluating mutant " + results.getMutation_id().hashCode() + " using tests: " + testClasses);
+            for (String test : testClasses) {
 
-				if  (test.contains("_scaffolding")) {
-					Main.debug("Skipped scaffolding test "+test);
-					continue;
-				}
+                if (test.contains("_scaffolding")) {
+                    Main.debug("Skipped scaffolding test " + test);
+                    continue;
+                }
 
-				// remove the prefix "testcases." added by our tool
-				if (test.startsWith("testcases."))
-					test = test.replaceFirst("testcases.", "");
+                // remove the prefix "testcases." added by our tool
+                if (test.startsWith("testcases."))
+                    test = test.replaceFirst("testcases.", "");
 
-				try {
-					// load the test case
-					final Class<?> testClass = cl.loadClass(test);
+                try {
+                    // load the test case
+                    final Class<?> testClass = cl.loadClass(test);
 
-					// Here we execute our test target class through its Runnable interface:
-					JUnitCore junit = new JUnitCore();
-					Result result = junit.run(testClass);
+                    // Here we execute our test target class through its
+                    // Runnable interface:
+                    // JUnitCore junit = new JUnitCore();
+                    // Result result = junit.run(testClass);
+                    // TODO: Replace the standard JUnitCore with our custom one
+                    // that:
+                    /*
+                     * TODO Flaky tests should not be considered TODO Tests in
+                     * timeout (because of the mutant) should not be considered?
+                     */
+                    StoppingJUnitCore junit = new StoppingJUnitCore();
 
-					results.addJUnitResult(result);
+                    long timeout = 5000;
+                    Result result = junit.run(testClass, timeout, flakyTests);
+                    // Initialize to survive as at least something ran !
+                    results.addJUnitResult(result);
 
-					// a failure here means that the mutation in the CUT
-					// is covered. Then, we don't need to run the remaining tests
-					if (result.getFailures().size() > 0) {
-						for (Failure fail : result.getFailures()){
-							String header = fail.getTestHeader();
+                    /*
+                     * Avoid to run the next testClass if the previous one
+                     * already killed the mutant a failure here means that the
+                     * mutation in the CUT is covered. Then, we don't need to
+                     * run the remaining tests.
+                     */
+                    if (result.getFailures().size() > 0) {
+                        for (Failure fail : result.getFailures()) {
+                            String header = fail.getTestHeader();
+                            if (header.contains("(")) {
+                                String testMethod = header.substring(0, header.indexOf('('));
+                                String tc = header.substring(header.indexOf('(') + 1, header.length());
+                                TestInfo info = new TestInfo(tc, testMethod);
+                                if (!this.flakyTests.contains(info)
+                                        && !fail.getTrace().contains("java.lang.Exception: test timed out after")) {
+                                    Main.debug("TestExec4MutationTask: Mutant " + results.getMutation_id().hashCode()
+                                            + " killed by test " + info);
+                                    results.setState(State.KILLED);
+                                    return results;
+                                }
+                            }
+                        }
+                        // TODO At this point, there were failures and those we
+                        // ALL invalid. What shall we do ?!
+                        Main.debug("TestExec4MutationTask: Ignore mutant " + results.getMutation_id().hashCode());
+                        results.setState(State.IGNORED);
+                        return results;
 
-							if (header.contains("(")){
-								String testMethod = header.substring(0, header.indexOf('('));
-								String tc = header.substring(header.indexOf('(')+1, header.length());
-								TestInfo info = new TestInfo(tc, testMethod);
-								if (!this.flakyTests.contains(info))
-									break;
-							}
-						}
-					}
+                    } else {
+                        /*
+                         * The mutant survives THIS test so it ran at least
+                         * once. However, other tests might change this state
+                         * later to KILLED.
+                         */
+                        results.setState(State.SURVIVED);
+                    }
+                } catch (Throwable e) {
+                    Main.debug("ERROR Failed Evaluating mutant " + results.getMutation_id().hashCode()
+                            + " using tests: " + testClasses);
+                    e.printStackTrace(Main.infoStr);
+                    results.setState(State.IGNORED);
+                }
+            }
+        }
+        Main.debug("Mutant " + results.getMutation_id().hashCode() + " survived ");
+        //
+        return results;
+    }
 
-					//Main.debug("Failure: "+result.getFailures());
-					//for (Failure fail : result.getFailures()){
-					//	Main.debug("Failing Tests: "+fail.getTestHeader()+"\n"+fail.getException()+"\n"+fail.getDescription()+"\n"+fail.getMessage());
-					//}
-				} catch (Exception e){
-					Main.debug("Exception running mutation task with test class: " + test);
-					e.printStackTrace(Main.debugStr);
-				}				
-			}
-			Main.debug("Executions terminated");
-			cl.close();
-			return results;
-	}
+    /**
+     * Count the number of failing test methods
+     * 
+     * @return number of failing test methods
+     */
+    public int countFailingTests() {
+        int count = 0;
 
-	/**
-	 * Count the number of failing test methods
-	 * @return number of failing test methods
-	 */
-	public int countFailingTests(){
-		int count = 0;
+        for (Result result : this.results.getJUnitResults()) {
+            count += result.getFailureCount();
+        }
+        return count;
+    }
 
-		for (Result result : this.results.getJUnitResults()){
-			count += result.getFailureCount();
-		}
-		return count;
-	}
-
-	public List<Result> getExecutionResults(){
-		return this.results.getJUnitResults();
-	}
+    public List<Result> getExecutionResults() {
+        return this.results.getJUnitResults();
+    }
 
 }

--- a/src/benchmarktool/src/test/java/sbst/benchmark/TestMain.java
+++ b/src/benchmarktool/src/test/java/sbst/benchmark/TestMain.java
@@ -13,14 +13,20 @@
   **/
 package sbst.benchmark;
 
-import java.io.IOException;
-
 import org.junit.Test;
 
 public class TestMain {
 
-	@Test
-	public void test1() throws IOException {
-		Main.main(new String[] {});
-	}
+//    @Ignore
+//	@Test
+//	public void test1() throws IOException {
+////		Main.main(new String[] {});
+//	}
+    
+    @Test(timeout=1000)
+    public void test2() throws InterruptedException{
+        System.out.println("TestMain.test2()");
+        Thread.currentThread().sleep( 5000 );
+        System.out.println("TestMain.test2()");
+    }
 }


### PR DESCRIPTION
- Create the Stopping JUnitCore class which wraps JUnitCore and replaces the standard test listener with a listener that can stop the execution as the first test fails as well as can discard flaky tests and tests that trigger the timeout
- Adjusted how mutants are handled by excluding ignored mutants